### PR TITLE
dcrdtest: Fix double harness teardown in test

### DIFF
--- a/dcrdtest/rpc_harness.go
+++ b/dcrdtest/rpc_harness.go
@@ -344,6 +344,21 @@ func (h *Harness) TearDown() error {
 	return nil
 }
 
+// TearDownInTest performs the TearDown during a test, logging the error to the
+// test object. If the test has not yet failed and the TearDown itself fails,
+// then this fails the test.
+func (h *Harness) TearDownInTest(t testing.TB) {
+	err := h.TearDown()
+	if err != nil {
+		errMsg := fmt.Sprintf("Unable to teardown dcrdtest harness: %v", err)
+		if !t.Failed() {
+			t.Fatalf(errMsg)
+		} else {
+			t.Logf(errMsg)
+		}
+	}
+}
+
 // connectRPCClient attempts to establish an RPC connection to the created dcrd
 // process belonging to this Harness instance. If the initial connection
 // attempt fails, this function will retry h.maxConnRetries times, backing off

--- a/dcrdtest/rpc_harness_test.go
+++ b/dcrdtest/rpc_harness_test.go
@@ -670,66 +670,64 @@ func TestHarness(t *testing.T) {
 	}
 
 	// Skip tests when running with -short
-	if !testing.Short() {
-		tests := []struct {
-			name string
-			f    func(context.Context, *Harness, *testing.T)
-		}{
-			{
-				f:    testSendOutputs,
-				name: "testSendOutputs",
-			},
-			{
-				f:    testConnectNode,
-				name: "testConnectNode",
-			},
-			{
-				f:    testDisconnectNode,
-				name: "testDisconnectNode",
-			},
-			{
-				f:    testNodesConnected,
-				name: "testNodesConnected",
-			},
-			{
-				f:    testActiveHarnesses,
-				name: "testActiveHarnesses",
-			},
-			{
-				f:    testJoinBlocks,
-				name: "testJoinBlocks",
-			},
-			{
-				f:    testJoinMempools, // Depends on results of testJoinBlocks
-				name: "testJoinMempools",
-			},
-			{
-				f:    testMemWalletReorg,
-				name: "testMemWalletReorg",
-			},
-			{
-				f:    testMemWalletLockedOutputs,
-				name: "testMemWalletLockedOutputs",
-			},
-		}
+	tests := []struct {
+		name string
+		f    func(context.Context, *Harness, *testing.T)
+	}{
+		{
+			f:    testSendOutputs,
+			name: "testSendOutputs",
+		},
+		{
+			f:    testConnectNode,
+			name: "testConnectNode",
+		},
+		{
+			f:    testDisconnectNode,
+			name: "testDisconnectNode",
+		},
+		{
+			f:    testNodesConnected,
+			name: "testNodesConnected",
+		},
+		{
+			f:    testActiveHarnesses,
+			name: "testActiveHarnesses",
+		},
+		{
+			f:    testJoinBlocks,
+			name: "testJoinBlocks",
+		},
+		{
+			f:    testJoinMempools, // Depends on results of testJoinBlocks
+			name: "testJoinMempools",
+		},
+		{
+			f:    testMemWalletReorg,
+			name: "testMemWalletReorg",
+		},
+		{
+			f:    testMemWalletLockedOutputs,
+			name: "testMemWalletLockedOutputs",
+		},
+	}
 
-		for _, testCase := range tests {
-			t.Logf("=== Running test: %v ===", testCase.name)
+	for _, testCase := range tests {
+		t.Logf("=== Running test: %v ===", testCase.name)
 
-			c := make(chan struct{})
-			go func() {
-				testCase.f(ctx, mainHarness, t)
-				c <- struct{}{}
-			}()
+		c := make(chan struct{})
+		go func() {
+			testCase.f(ctx, mainHarness, t)
+			c <- struct{}{}
+		}()
 
-			// Go wait for 10 seconds
-			select {
-			case <-c:
-			case <-time.After(10 * time.Second):
-				t.Logf("Test timeout, aborting running nodes")
-				PanicAll(t)
-				os.Exit(1)
-			}
+		// Go wait for 10 seconds
+		select {
+		case <-c:
+		case <-time.After(10 * time.Second):
+			t.Logf("Test timeout, aborting running nodes")
+			PanicAll(t)
+			os.Exit(1)
 		}
 	}
 

--- a/dcrdtest/votingwallet_test.go
+++ b/dcrdtest/votingwallet_test.go
@@ -87,7 +87,7 @@ func TestMinimalVotingWallet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer hn.TearDown()
+	defer hn.TearDownInTest(t)
 
 	if _, err := AdjustedSimnetMiner(ctx, hn.Node, 64); err != nil {
 		t.Fatal(err)
@@ -135,10 +135,5 @@ func TestMinimalVotingWallet(t *testing.T) {
 		if !success {
 			break
 		}
-	}
-
-	err = hn.TearDown()
-	if err != nil {
-		t.Fatalf("errored while tearing down test harness: %v", err)
 	}
 }

--- a/dcrdtest/votingwallet_test.go
+++ b/dcrdtest/votingwallet_test.go
@@ -52,11 +52,6 @@ func testCanPassSVH(ctx context.Context, t *testing.T, vw *VotingWallet) {
 }
 
 func TestMinimalVotingWallet(t *testing.T) {
-	// Skip tests when running with -short
-	if testing.Short() {
-		t.Skip("Skipping minimal voting wallet in short mode")
-	}
-
 	var handlers *rpcclient.NotificationHandlers
 	net := chaincfg.SimNetParams()
 


### PR DESCRIPTION
This removes the douplicate TearDown() call in the TestVotingWallet test that was causing erroneous messages to be shown.