### PR TITLE
CI: Add additional OSs to build matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,10 +6,11 @@ permissions:
 jobs:
   build:
     name: Go CI
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         go: [1.18, 1.19]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       # Prepare env.
       - name: Set up Go
@@ -18,6 +19,11 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: Install Linters
         run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.0"
+        shell: bash
+      - name: Set git config to please linters
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
       # Test repository.
       - name: Check out source


### PR DESCRIPTION
This adds macOS and windows as targets for the Github Actions CI.