### PR TITLE
dcrdtest: Minor cleanups

### DIFF
--- a/dcrdtest/rpc_harness_test.go
+++ b/dcrdtest/rpc_harness_test.go
@@ -833,4 +833,9 @@ func TestKeepNodeDir(t *testing.T) {
 		t.Fatalf("Unexpected Stat(testNodeDir) error: got %v, want %v",
 			err, nil)
 	}
+
+	// Manually remove the dir to clean up after this test.
+	if err := os.RemoveAll(mainHarness.testNodeDir); err != nil {
+		t.Fatalf("Unable to cleanup testNodeDir: %v", err)
+	}
 }


### PR DESCRIPTION
The first commit removes the need for a global mutex lock in New(). Fix #3

The second commit cleans up a test dir that was not automatically cleaned up.

